### PR TITLE
Add SVG exports

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1684,6 +1684,11 @@
       "integrity": "sha512-yYQ2QfotceRiH4U+h1Us86WJXtVHDmy3nEKIdYPsZCYnOV5/tMgGbmoIlrMzmh2VXlproqYtVaKeGDBkMZifFA==",
       "dev": true
     },
+    "canvas2svg": {
+      "version": "1.0.16",
+      "resolved": "https://registry.npmjs.org/canvas2svg/-/canvas2svg-1.0.16.tgz",
+      "integrity": "sha1-CBTFO7q3w0Buc4cnnN8lf+T28r0="
+    },
     "cardinal": {
       "version": "0.4.4",
       "resolved": "https://registry.npmjs.org/cardinal/-/cardinal-0.4.4.tgz",
@@ -4280,7 +4285,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -4301,12 +4307,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -4321,17 +4329,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -4448,7 +4459,8 @@
         "inherits": {
           "version": "2.0.4",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -4460,6 +4472,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -4474,6 +4487,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -4481,12 +4495,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.9.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -4505,6 +4521,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -4594,7 +4611,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -4606,6 +4624,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -4691,7 +4710,8 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -4727,6 +4747,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -4746,6 +4767,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -4789,12 +4811,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -5666,6 +5690,11 @@
       "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.5.1.tgz",
       "integrity": "sha512-M7kLczedRMYX4L8Mdh4MzyAMM9O5osx+4FcOQuTvr3A9F2D9S5JXheN0ewNbrvK2UatkTRhL5ejGmGSjNMiZuw==",
       "dev": true
+    },
+    "js-file-download": {
+      "version": "0.4.9",
+      "resolved": "https://registry.npmjs.org/js-file-download/-/js-file-download-0.4.9.tgz",
+      "integrity": "sha512-/qFei3bAo/BmV05ScKp3KDUMf57qD6UVkMa1gfOnwpLHuuHXRNXW42QbcQPi8+1Kn5LSrTEM28V2cooeHsU66w=="
     },
     "js-tokens": {
       "version": "3.0.2",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,8 @@
   "dependencies": {
     "@mapbox/mapbox-gl-geocoder": "^2.3.0",
     "@mapbox/tilebelt": "^1.0.1",
+    "canvas2svg": "^1.0.16",
+    "js-file-download": "^0.4.9",
     "mapbox-gl": "^1.6.0",
     "tinycolor2": "^1.4.1",
     "vue": "^2.5.2",

--- a/src/App.vue
+++ b/src/App.vue
@@ -93,6 +93,9 @@
 
             </div>
           </div>
+          <div class='row'>
+            <a href="#" title='Download SVG' @click.prevent='downloadSVG'>Download SVG</a>
+          </div>
         </div>
 
         <div class='close-link'>
@@ -130,6 +133,7 @@ import ColorPicker from './components/ColorPicker';
 import Loading from './components/Loading';
 import About from './components/About';
 import generateZazzleLink from './lib/getZazzleLink';
+import fileDownload from 'js-file-download';
 
 export default {
   name: 'App',
@@ -218,6 +222,11 @@ export default {
 
     updateLinesColor(x) {
       this.redraw();
+    },
+
+    downloadSVG() {
+      const svg = appState.svgContext.getSerializedSvg();
+      fileDownload(svg, 'lines.svg');
     },
 
     previewOrOpen() {

--- a/src/appState.js
+++ b/src/appState.js
@@ -10,6 +10,7 @@ const appState = {
   aboutVisible: false,
   error: null,
   zazzleLink: null,
+  svgContext: null,
   generatingPreview: false,
   settingsOpen: false,
   shouldDraw: false,


### PR DESCRIPTION
Adds a button for downloading the current image as an SVG file.

You may notice that in browsers that have a 'downloaded' files strip
at the bottom of the window (such as Chrome), the lines are redrawn
after the first download. This is just because the inner window
size is changing due to the download strip.